### PR TITLE
fix: Instruct hackmd agent not to modify large meeting index

### DIFF
--- a/hackmd_agent/agent.py
+++ b/hackmd_agent/agent.py
@@ -73,17 +73,19 @@ root_agent = LlmAgent(
         Use the tools to access to HackMD, GitHub, and Discord.
 
         The HackMD ID of the meeting note index is `x232chPbTfGgNL_Q0f47rQ`.
+        - The meeting note index is very large and read-only. DO NOT attempt to modify it using tools.
         - In the meeting note index, you can find list of hyperlinks in Markdown format.
         - Each link href contains a HackMD document ID prepended by `/`.
 
         When the user says the meeting ends, you should help them to:
-        1. Generate a title for the current meeting note.
+        1. Generate a title for the current meeting note. Present the title to the user and ask them to manually update the meeting note index.
         2. Summarize actionable items from the meeting note.
             - If the actionable item is creating Github tickets, present a draft ticket and ask
                 the user to confirm if they want to create the ticket.
         3. Create a new HackMD document for the next meeting note.
             - Draft the new document containing items to follow-up next week.
             - Ask the user to confirm if they want to create the document on HackMD.
+            - Once created, generate a Markdown bullet point containing the link to the new note and present it to the user, asking them to manually paste it into the meeting note index.
 
         You are also connected to Cofacts' Discord server with related tools. You can read messages from channels.
 

--- a/hackmd_agent/agent.py
+++ b/hackmd_agent/agent.py
@@ -85,7 +85,7 @@ root_agent = LlmAgent(
         3. Create a new HackMD document for the next meeting note.
             - Draft the new document containing items to follow-up next week.
             - Ask the user to confirm if they want to create the document on HackMD.
-            - Once created, generate a Markdown bullet point containing the link to the new note and present it to the user, asking them to manually paste it into the meeting note index.
+            - Once created, generate a Markdown bullet point for the new note (e.g., - [YYYYMMDD 會議記錄](/ID)) and present it to the user, asking them to manually paste it into the meeting note index.
 
         You are also connected to Cofacts' Discord server with related tools. You can read messages from channels.
 


### PR DESCRIPTION
Fixes an issue where the hackmd_agent attempts to modify the meeting index document which is too large for the HackMD API, causing failures.

Changes made:
- Updated the agent prompt to explicitly declare the meeting note index as read-only.
- Modified the instructions so the agent presents the generated title and asks the user to manually update the index.
- Modified the instructions so the agent generates a markdown bullet point with the new note's link and presents it for the user to manually copy and paste.

---
*PR created automatically by Jules for task [8119812211582386096](https://jules.google.com/task/8119812211582386096) started by @MrOrz*